### PR TITLE
Add soft delete method with a given visibility

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -57,7 +57,15 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
 
     @Override
     public void softDeleteProperty(String key, String name, Authorizations authorizations) {
-        Property property = super.removePropertyInternal(key, name);
+        Property property = super.softDeletePropertyInternal(key, name);
+        if (property != null) {
+            getGraph().softDeleteProperty(this, property, authorizations);
+        }
+    }
+
+    @Override
+    public void softDeleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
+        Property property = super.softDeletePropertyInternal(key, name, visibility);
         if (property != null) {
             getGraph().softDeleteProperty(this, property, authorizations);
         }

--- a/core/src/main/java/org/vertexium/Element.java
+++ b/core/src/main/java/org/vertexium/Element.java
@@ -209,6 +209,16 @@ public interface Element {
     void softDeleteProperty(String key, String name, Authorizations authorizations);
 
     /**
+     * Soft deletes a property given it's key and name from the element for a given visibility. Only properties which you have access
+     * to can be soft deleted using this method.
+     *
+     * @param key  The property key.
+     * @param name The property name.
+     * @param visibility The visibility string of the property to soft delete.
+     */
+    void softDeleteProperty(String key, String name, Visibility visibility, Authorizations authorizations);
+
+    /**
      * Soft deletes all properties with the given name that you have access to. Only properties which you have
      * access to will be soft deleted.
      *

--- a/core/src/main/java/org/vertexium/ElementBase.java
+++ b/core/src/main/java/org/vertexium/ElementBase.java
@@ -277,6 +277,15 @@ public abstract class ElementBase implements Element {
         return property;
     }
 
+    protected Property softDeletePropertyInternal(String key, String name, Visibility visibility) {
+        Property property = getProperty(key, name, visibility);
+        if (property != null) {
+            this.properties.remove(property);
+        }
+        this.softDeletedProperties.add(property);
+        return property;
+    }
+
     protected Iterable<Property> removePropertyInternal(String name) {
         List<Property> removedProperties = new ArrayList<>();
         for (Property p : this.properties) {
@@ -343,6 +352,9 @@ public abstract class ElementBase implements Element {
 
     @Override
     public abstract void softDeleteProperty(String key, String name, Authorizations authorizations);
+
+    @Override
+    public abstract void softDeleteProperty(String key, String name, Visibility visibility, Authorizations authorizations);
 
     @Override
     public abstract void softDeleteProperties(String name, Authorizations authorizations);

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -74,6 +74,14 @@ public abstract class InMemoryElement extends ElementBase {
     }
 
     @Override
+    public void softDeleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
+        Property property = softDeletePropertyInternal(key, name, visibility);
+        if (property != null) {
+            getGraph().softDeleteProperty(this, property, authorizations);
+        }
+    }
+
+    @Override
     public void softDeleteProperties(String name, Authorizations authorizations) {
         Iterable<Property> properties = softDeletePropertyInternal(name);
         for (Property property : properties) {

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -626,6 +626,24 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testSoftDeletePropertyWithVisibility() {
+        Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
+                .addPropertyValue("key1", "name1", "value1", VISIBILITY_A)
+                .addPropertyValue("key1", "name1", "value2", VISIBILITY_B)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        assertEquals(2, count(graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getProperties()));
+        org.vertexium.test.util.IterableUtils.assertContains("value1", v1.getPropertyValues("name1"));
+        org.vertexium.test.util.IterableUtils.assertContains("value2", v1.getPropertyValues("name1"));
+
+        graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).softDeleteProperty("key1", "name1", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        assertEquals(1, count(graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getProperties()));
+        assertEquals(1, count(graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getPropertyValues("key1", "name1")));
+        org.vertexium.test.util.IterableUtils.assertContains("value2", graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getPropertyValues("name1"));
+    }
+
+    @Test
     public void testSoftDeletePropertyThroughMutationWithVisibility() {
         Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
                 .addPropertyValue("key1", "name1", "value1", VISIBILITY_A)

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -331,13 +331,13 @@ public abstract class GraphTestBase {
 
     @Test
     public void testMultivaluedProperties() {
-        Vertex v = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_ALL);
 
         v.prepareMutation()
                 .addPropertyValue("propid1a", "prop1", "value1a", VISIBILITY_A)
                 .addPropertyValue("propid2a", "prop2", "value2a", VISIBILITY_A)
                 .addPropertyValue("propid3a", "prop3", "value3a", VISIBILITY_A)
-                .save(AUTHORIZATIONS_A_AND_B);
+                .save(AUTHORIZATIONS_ALL);
         v = graph.getVertex("v1", AUTHORIZATIONS_A);
         assertEquals("value1a", v.getPropertyValues("prop1").iterator().next());
         assertEquals("value2a", v.getPropertyValues("prop2").iterator().next());
@@ -1775,14 +1775,14 @@ public abstract class GraphTestBase {
 
     @Test
     public void testVertexQuery() {
-        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        v1.setProperty("prop1", "value1", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_ALL);
+        v1.setProperty("prop1", "value1", VISIBILITY_A, AUTHORIZATIONS_ALL);
 
-        Vertex v2 = graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
-        v2.setProperty("prop1", "value2", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        Vertex v2 = graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_ALL);
+        v2.setProperty("prop1", "value2", VISIBILITY_A, AUTHORIZATIONS_ALL);
 
-        Vertex v3 = graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_A);
-        v3.setProperty("prop1", "value3", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        Vertex v3 = graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_ALL);
+        v3.setProperty("prop1", "value3", VISIBILITY_A, AUTHORIZATIONS_ALL);
 
         Edge ev1v2 = graph.addEdge("e v1->v2", v1, v2, "edgeA", VISIBILITY_A, AUTHORIZATIONS_A);
         Edge ev1v3 = graph.addEdge("e v1->v3", v1, v3, "edgeA", VISIBILITY_A, AUTHORIZATIONS_A);
@@ -2049,8 +2049,8 @@ public abstract class GraphTestBase {
 
     @Test
     public void testElementMutationDoesntChangeObjectUntilSave() {
-        Vertex v = graph.addVertex("v1", VISIBILITY_EMPTY, AUTHORIZATIONS_EMPTY);
-        v.setProperty("prop1", "value1", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        Vertex v = graph.addVertex("v1", VISIBILITY_EMPTY, AUTHORIZATIONS_ALL);
+        v.setProperty("prop1", "value1", VISIBILITY_A, AUTHORIZATIONS_ALL);
 
         ElementMutation<Vertex> m = v.prepareMutation()
                 .setProperty("prop1", "value2", VISIBILITY_A)
@@ -2142,8 +2142,8 @@ public abstract class GraphTestBase {
 
     @Test
     public void testEmptyPropertyMutation() {
-        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        v1.prepareMutation().save(AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_ALL);
+        v1.prepareMutation().save(AUTHORIZATIONS_ALL);
     }
 
     @Test
@@ -2584,14 +2584,14 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .setProperty("prop1", "value1", VISIBILITY_A)
                 .setIndexHint(IndexHint.DO_NOT_INDEX)
                 .save(AUTHORIZATIONS_A);
         graph.flush();
 
-        Iterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A_AND_B)
+        Iterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A)
                 .has("prop1", "value1")
                 .vertices();
         assertVertexIds(vertices, new String[]{});

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -626,6 +626,27 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testSoftDeletePropertyThroughMutationWithVisibility() {
+        Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
+                .addPropertyValue("key1", "name1", "value1", VISIBILITY_A)
+                .addPropertyValue("key1", "name1", "value2", VISIBILITY_B)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        assertEquals(2, count(graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getProperties()));
+        org.vertexium.test.util.IterableUtils.assertContains("value1", v1.getPropertyValues("name1"));
+        org.vertexium.test.util.IterableUtils.assertContains("value2", v1.getPropertyValues("name1"));
+
+        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B)
+                .prepareMutation()
+                .softDeleteProperty("key1", "name1", VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        assertEquals(1, count(v1.getProperties()));
+        assertEquals(1, count(v1.getPropertyValues("key1", "name1")));
+        org.vertexium.test.util.IterableUtils.assertContains("value2", v1.getPropertyValues("name1"));
+    }
+
+    @Test
     public void testAddVertexWithVisibility() {
         graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_ALL);
         graph.addVertex("v2", VISIBILITY_B, AUTHORIZATIONS_ALL);


### PR DESCRIPTION
-  Fix Unit Tests that were failing
- Added a method that will soft delete a property that matches a given property key, property name and visibility