### PR TITLE
add TermsAggregation support to DefaultGraphQuery

### DIFF
--- a/core/src/main/java/org/vertexium/query/DefaultGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQuery.java
@@ -16,13 +16,27 @@ public class DefaultGraphQuery extends GraphQueryBase {
     @Override
     public QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints) {
         LOGGER.warn("scanning all vertices! create your own GraphQuery.");
-        return new DefaultGraphQueryIterable<>(getParameters(), this.<Vertex>getIterableFromElementType(ElementType.VERTEX, fetchHints), true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(
+                getParameters(),
+                this.<Vertex>getIterableFromElementType(ElementType.VERTEX, fetchHints),
+                true,
+                true,
+                true,
+                getAggregations()
+        );
     }
 
     @Override
     public QueryResultsIterable<Edge> edges(EnumSet<FetchHint> fetchHints) {
         LOGGER.warn("scanning all edges! create your own GraphQuery.");
-        return new DefaultGraphQueryIterable<>(getParameters(), this.<Edge>getIterableFromElementType(ElementType.EDGE, fetchHints), true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(
+                getParameters(),
+                this.<Edge>getIterableFromElementType(ElementType.EDGE, fetchHints),
+                true,
+                true,
+                true,
+                getAggregations()
+        );
     }
 
     @SuppressWarnings("unchecked")
@@ -35,5 +49,13 @@ public class DefaultGraphQuery extends GraphQueryBase {
             default:
                 throw new VertexiumException("Unexpected element type: " + elementType);
         }
+    }
+
+    @Override
+    public boolean isAggregationSupported(Aggregation aggregation) {
+        if (DefaultGraphQueryIterableWithAggregations.isAggregationSupported(aggregation)) {
+            return true;
+        }
+        return super.isAggregationSupported(aggregation);
     }
 }

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
@@ -4,7 +4,6 @@ import org.vertexium.Edge;
 import org.vertexium.Element;
 import org.vertexium.Property;
 import org.vertexium.VertexiumException;
-import org.vertexium.util.CloseableIterable;
 import org.vertexium.util.CloseableIterator;
 import org.vertexium.util.CloseableUtils;
 
@@ -51,7 +50,7 @@ public class DefaultGraphQueryIterable<T extends Element> implements
         return iterator(false);
     }
 
-    private Iterator<T> iterator(final boolean iterateAll) {
+    protected Iterator<T> iterator(final boolean iterateAll) {
         final Iterator<T> it = iterable.iterator();
 
         return new CloseableIterator<T>() {

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterableWithAggregations.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterableWithAggregations.java
@@ -1,0 +1,86 @@
+package org.vertexium.query;
+
+import org.vertexium.Element;
+import org.vertexium.VertexiumException;
+
+import java.util.*;
+
+public class DefaultGraphQueryIterableWithAggregations<T extends Element> extends DefaultGraphQueryIterable<T> {
+    private final Collection<Aggregation> aggregations;
+
+    public DefaultGraphQueryIterableWithAggregations(
+            QueryParameters parameters,
+            Iterable<T> iterable,
+            boolean evaluateQueryString,
+            boolean evaluateHasContainers,
+            boolean evaluateSortContainers,
+            Collection<Aggregation> aggregations
+    ) {
+        super(parameters, iterable, evaluateQueryString, evaluateHasContainers, evaluateSortContainers);
+        this.aggregations = aggregations;
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        for (Aggregation agg : this.aggregations) {
+            if (agg.getAggregationName().equals(name)) {
+                return getAggregationResult(agg, this.iterator(true));
+            }
+        }
+        return super.getAggregationResult(name, resultType);
+    }
+
+    public static boolean isAggregationSupported(Aggregation agg) {
+        if (agg instanceof TermsAggregation) {
+            return true;
+        }
+        return false;
+    }
+
+    public <TResult extends AggregationResult> TResult getAggregationResult(Aggregation agg, Iterator<T> it) {
+        if (agg instanceof TermsAggregation) {
+            return getTermsAggregationResult((TermsAggregation) agg, it);
+        }
+        throw new VertexiumException("Unhandled aggregation: " + agg.getClass().getName());
+    }
+
+    private <TResult extends AggregationResult> TResult getTermsAggregationResult(TermsAggregation agg, Iterator<T> it) {
+        String propertyName = agg.getPropertyName();
+        Map<Object, List<T>> elementsByProperty = getElementsByProperty(it, propertyName);
+
+        List<TermsBucket> buckets = new ArrayList<>();
+        for (Map.Entry<Object, List<T>> entry : elementsByProperty.entrySet()) {
+            Object key = entry.getKey();
+            int count = entry.getValue().size();
+            Map<String, AggregationResult> nestedResults = getNestedResults(agg.getNestedAggregations(), entry.getValue());
+            buckets.add(new TermsBucket(key, count, nestedResults));
+        }
+        return (TResult) new TermsResult(buckets);
+    }
+
+    private Map<String, AggregationResult> getNestedResults(Iterable<Aggregation> nestedAggregations, List<T> elements) {
+        Map<String, AggregationResult> results = new HashMap<>();
+        for (Aggregation nestedAggregation : nestedAggregations) {
+            AggregationResult nestedResult = getAggregationResult(nestedAggregation, elements.iterator());
+            results.put(nestedAggregation.getAggregationName(), nestedResult);
+        }
+        return results;
+    }
+
+    private Map<Object, List<T>> getElementsByProperty(Iterator<T> it, String propertyName) {
+        Map<Object, List<T>> elementsByProperty = new HashMap<>();
+        while (it.hasNext()) {
+            T elem = it.next();
+            Iterable<Object> values = elem.getPropertyValues(propertyName);
+            for (Object value : values) {
+                List<T> list = elementsByProperty.get(value);
+                if (list == null) {
+                    list = new ArrayList<T>();
+                    elementsByProperty.put(value, list);
+                }
+                list.add(elem);
+            }
+        }
+        return elementsByProperty;
+    }
+}

--- a/core/src/main/java/org/vertexium/query/DefaultMultiVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultMultiVertexQuery.java
@@ -17,7 +17,7 @@ public class DefaultMultiVertexQuery extends QueryBase implements MultiVertexQue
     @Override
     public QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints) {
         Iterable<Vertex> vertices = getGraph().getVertices(IterableUtils.toIterable(getVertexIds()), fetchHints, getParameters().getAuthorizations());
-        return new DefaultGraphQueryIterable<>(getParameters(), vertices, true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(getParameters(), vertices, true, true, true, getAggregations());
     }
 
     @Override
@@ -25,7 +25,7 @@ public class DefaultMultiVertexQuery extends QueryBase implements MultiVertexQue
         Iterable<Vertex> vertices = getGraph().getVertices(IterableUtils.toIterable(getVertexIds()), fetchHints, getParameters().getAuthorizations());
         Iterable<String> edgeIds = new VerticesToEdgeIdsIterable(vertices, getParameters().getAuthorizations());
         Iterable<Edge> edges = getGraph().getEdges(edgeIds, fetchHints, getParameters().getAuthorizations());
-        return new DefaultGraphQueryIterable<>(getParameters(), edges, true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(getParameters(), edges, true, true, true, getAggregations());
     }
 
     public String[] getVertexIds() {

--- a/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
@@ -3,7 +3,6 @@ package org.vertexium.query;
 import org.vertexium.*;
 
 import java.util.EnumSet;
-import java.util.Map;
 
 public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
     public DefaultVertexQuery(Graph graph, Vertex sourceVertex, String queryString, Authorizations authorizations) {
@@ -13,12 +12,12 @@ public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
     @Override
     public QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints) {
         Iterable<Vertex> vertices = getSourceVertex().getVertices(Direction.BOTH, fetchHints, getParameters().getAuthorizations());
-        return new DefaultGraphQueryIterable<>(getParameters(), vertices, true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(getParameters(), vertices, true, true, true, getAggregations());
     }
 
     @Override
     public QueryResultsIterable<Edge> edges(EnumSet<FetchHint> fetchHints) {
         Iterable<Edge> edges = getSourceVertex().getEdges(Direction.BOTH, fetchHints, getParameters().getAuthorizations());
-        return new DefaultGraphQueryIterable<>(getParameters(), edges, true, true, true);
+        return new DefaultGraphQueryIterableWithAggregations<>(getParameters(), edges, true, true, true, getAggregations());
     }
 }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -4109,7 +4109,7 @@ public abstract class GraphTestBase {
             return null;
         }
         q.addAggregation(agg);
-        TermsResult aggregationResult = ((QueryResultsIterable<Vertex>) q.vertices()).getAggregationResult("terms-count", TermsResult.class);
+        TermsResult aggregationResult = q.vertices().getAggregationResult("terms-count", TermsResult.class);
         return nestedTermsBucketToMap(aggregationResult.getBuckets(), "nested");
     }
 


### PR DESCRIPTION
This should only affect you if you are running without Elasticsearch. This will do an in-memory terms aggregation of your data.