### PR TITLE
add table name into the context classpath variable to potentially hav…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.3.2
+ * ACCUMULO: iterator locations in accumulo config are now stored per table name
+
 # v2.3.1
 
 * Elasticsearch: fix calendar date field aggregations with multiple visibilities

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -225,8 +225,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             }
 
             if (hdfsContextClasspath != null) {
-                connector.instanceOperations().setProperty("general.vfs.context.classpath." + CLASSPATH_CONTEXT_NAME, hdfsContextClasspath);
-                connector.tableOperations().setProperty(tableName, "table.classpath.context", CLASSPATH_CONTEXT_NAME);
+                connector.instanceOperations().setProperty("general.vfs.context.classpath." + CLASSPATH_CONTEXT_NAME + "-" + tableName, hdfsContextClasspath);
+                connector.tableOperations().setProperty(tableName, "table.classpath.context", CLASSPATH_CONTEXT_NAME + "-" + tableName);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to create table " + tableName, e);


### PR DESCRIPTION
…e different iterators on the classpath


I know that there may be potential issues with classpaths potentially bleeding if there are updates to the iterators that are going to mismatch versions, but this is at least a start that will allow multiple user contexts to have their own iterators on the classpath and they won't overwrite each other's path's when different clients connect with different user names.