### PR TITLE
Elasticsearch: fix: sort by strings with tokens should not effect sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # v2.3.2
- * ACCUMULO: iterator locations in accumulo config are now stored per table name
+
+* ACCUMULO: iterator locations in accumulo config are now stored per table name
+* Elasticsearch: fix: sort by strings with tokens should not effect sort order 
 
 # v2.3.1
 
-* Elasticsearch: fix calendar date field aggregations with multiple visibilities
+* Elasticsearch: fix: calendar date field aggregations with multiple visibilities
 * Elasticsearch: Support additional configuration for in process node
 * Elasticsearch: fix: Aggregation after alter visibility
 * SQL: fix: refresh in memory representation after altering vertex visibility

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -241,7 +241,7 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                 if (!propertyDefinition.isSortable()) {
                     throw new VertexiumException("Cannot sort on non-sortable fields");
                 }
-                q.addSort(propertyDefinition.getPropertyName(), esOrder);
+                q.addSort(propertyDefinition.getPropertyName() + ElasticsearchSingleDocumentSearchIndex.SORT_PROPERTY_NAME_SUFFIX, esOrder);
             }
         }
     }


### PR DESCRIPTION
@sfeng88 @srfarley 

Sorting vertices with values "1-1" and "1-2" previously would not sort consistently because Elasticsearch would tokenize on `-`.

To avoid conflicts with existing "analyzed" sort fields I added a `_s` suffix to sorted fields (which I should have done in the first place anyway).

Can you think of some other unit tests I can add to verify the sort order is correct?