### PR TITLE
Add a helper method to check for an empty Iterable

### DIFF
--- a/core/src/main/java/org/vertexium/util/IterableUtils.java
+++ b/core/src/main/java/org/vertexium/util/IterableUtils.java
@@ -76,6 +76,15 @@ public class IterableUtils {
         return count;
     }
 
+    public static <T> boolean isEmpty(Iterable<T> iterable) {
+        Iterator<T> iterator = iterable.iterator();
+        try {
+            return !iterator.hasNext();
+        } finally {
+            closeQuietly(iterator);
+        }
+    }
+
     public static <T> Iterable<T> toIterable(final T[] arr) {
         return new Iterable<T>() {
             @Override

--- a/core/src/test/java/org/vertexium/util/IterableUtilsTest.java
+++ b/core/src/test/java/org/vertexium/util/IterableUtilsTest.java
@@ -4,9 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.*;
+import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -18,5 +17,4 @@ public class IterableUtilsTest {
         assertTrue(IterableUtils.isEmpty(Collections.emptyList()));
         assertFalse(IterableUtils.isEmpty(Collections.singletonList("junit")));
     }
-
 }

--- a/core/src/test/java/org/vertexium/util/IterableUtilsTest.java
+++ b/core/src/test/java/org/vertexium/util/IterableUtilsTest.java
@@ -1,0 +1,22 @@
+package org.vertexium.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class IterableUtilsTest {
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(IterableUtils.isEmpty(Collections.emptyList()));
+        assertFalse(IterableUtils.isEmpty(Collections.singletonList("junit")));
+    }
+
+}


### PR DESCRIPTION
In order to check for an empty Iterable, it's a little messy to have to get an Iterator, check hasNext, then close the iterator. This encapsulates that logic into an isEmpty method