### PR TITLE
update InMemoryVertex implementations of getVertices and getVertexIds

### DIFF
--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -238,12 +238,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, final EnumSet<FetchHint> fetchHints, final Authorizations authorizations) {
-        return new ConvertingIterable<Edge, Vertex>(getEdges(direction, authorizations)) {
-            @Override
-            protected Vertex convert(Edge edge) {
-                return getOtherVertexFromEdge(edge, authorizations);
-            }
-        };
+        return getVertices(direction, (String[])null, fetchHints, authorizations);
     }
 
     @Override
@@ -253,7 +248,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String label, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
-        return getVertices(direction, labelToArrayOrNull(label), authorizations);
+        return getVertices(direction, labelToArrayOrNull(label), fetchHints, authorizations);
     }
 
     @Override
@@ -263,52 +258,28 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(final Direction direction, final String[] labels, final EnumSet<FetchHint> fetchHints, final Authorizations authorizations) {
-        return new ConvertingIterable<Edge, Vertex>(getEdges(direction, labels, authorizations)) {
-            @Override
-            protected Vertex convert(Edge edge) {
-                return getOtherVertexFromEdge(edge, authorizations);
-            }
-        };
+        Iterable<String> vertexIds = getVertexIds(direction, labels, authorizations);
+        return getGraph().getVertices(vertexIds, fetchHints, authorizations);
     }
 
     @Override
     public Iterable<String> getVertexIds(Direction direction, String label, Authorizations authorizations) {
-        return new ConvertingIterable<Vertex, String>(getVertices(direction, label, authorizations)) {
-            @Override
-            protected String convert(Vertex o) {
-                return o.getId();
-            }
-        };
+        return getVertexIds(direction, labelToArrayOrNull(label), authorizations);
     }
 
     @Override
     public Iterable<String> getVertexIds(Direction direction, String[] labels, Authorizations authorizations) {
-        return new ConvertingIterable<Vertex, String>(getVertices(direction, labels, authorizations)) {
+        return new ConvertingIterable<EdgeInfo, String>(getEdgeInfos(direction, labels, authorizations)) {
             @Override
-            protected String convert(Vertex o) {
-                return o.getId();
+            protected String convert(EdgeInfo e) {
+                return e.getVertexId();
             }
         };
     }
 
     @Override
     public Iterable<String> getVertexIds(Direction direction, Authorizations authorizations) {
-        return new ConvertingIterable<Vertex, String>(getVertices(direction, authorizations)) {
-            @Override
-            protected String convert(Vertex o) {
-                return o.getId();
-            }
-        };
-    }
-
-    private Vertex getOtherVertexFromEdge(Edge edge, Authorizations authorizations) {
-        if (edge.getVertexId(Direction.IN).equals(getId())) {
-            return edge.getVertex(Direction.OUT, authorizations);
-        }
-        if (edge.getVertexId(Direction.OUT).equals(getId())) {
-            return edge.getVertex(Direction.IN, authorizations);
-        }
-        throw new IllegalStateException("Edge does not contain vertex on either end");
+        return getVertexIds(direction, (String[])null, authorizations);
     }
 
     @Override

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3111,10 +3111,12 @@ public abstract class GraphTestBase {
         Vertex v2 = graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
         Vertex v3 = graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_A);
         Vertex v4 = graph.addVertex("v4", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v5 = graph.addVertex("v5", VISIBILITY_B, AUTHORIZATIONS_B);
         graph.addEdge(v1, v2, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
         graph.addEdge(v1, v3, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
         graph.addEdge(v1, v4, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
         graph.addEdge(v2, v3, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.addEdge(v2, v5, "knows", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
@@ -3136,6 +3138,41 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(v4.getVertices(Direction.BOTH, AUTHORIZATIONS_A)));
         Assert.assertEquals(0, count(v4.getVertices(Direction.OUT, AUTHORIZATIONS_A)));
         Assert.assertEquals(1, count(v4.getVertices(Direction.IN, AUTHORIZATIONS_A)));
+    }
+
+    @Test
+    public void testGetVertexIdsFromVertex() {
+        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v2 = graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v3 = graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v4 = graph.addVertex("v4", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v5 = graph.addVertex("v5", VISIBILITY_B, AUTHORIZATIONS_B);
+        graph.addEdge(v1, v2, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.addEdge(v1, v3, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.addEdge(v1, v4, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.addEdge(v2, v3, "knows", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.addEdge(v2, v5, "knows", VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Assert.assertEquals(3, count(v1.getVertexIds(Direction.BOTH, AUTHORIZATIONS_A)));
+        Assert.assertEquals(3, count(v1.getVertexIds(Direction.OUT, AUTHORIZATIONS_A)));
+        Assert.assertEquals(0, count(v1.getVertexIds(Direction.IN, AUTHORIZATIONS_A)));
+
+        v2 = graph.getVertex("v2", AUTHORIZATIONS_A);
+        Assert.assertEquals(3, count(v2.getVertexIds(Direction.BOTH, AUTHORIZATIONS_A)));
+        Assert.assertEquals(2, count(v2.getVertexIds(Direction.OUT, AUTHORIZATIONS_A)));
+        Assert.assertEquals(1, count(v2.getVertexIds(Direction.IN, AUTHORIZATIONS_A)));
+
+        v3 = graph.getVertex("v3", AUTHORIZATIONS_A);
+        Assert.assertEquals(2, count(v3.getVertexIds(Direction.BOTH, AUTHORIZATIONS_A)));
+        Assert.assertEquals(0, count(v3.getVertexIds(Direction.OUT, AUTHORIZATIONS_A)));
+        Assert.assertEquals(2, count(v3.getVertexIds(Direction.IN, AUTHORIZATIONS_A)));
+
+        v4 = graph.getVertex("v4", AUTHORIZATIONS_A);
+        Assert.assertEquals(1, count(v4.getVertexIds(Direction.BOTH, AUTHORIZATIONS_A)));
+        Assert.assertEquals(0, count(v4.getVertexIds(Direction.OUT, AUTHORIZATIONS_A)));
+        Assert.assertEquals(1, count(v4.getVertexIds(Direction.IN, AUTHORIZATIONS_A)));
     }
 
     @Test


### PR DESCRIPTION
In order to make it behave consistently with the Accumulo implementation. When faced with edges that can be seen to Vertices that can't be seen, getVertices will omit them and getVertexIds will return the ids