### PR TITLE
Accumulo: fix accumulo not cleaning up property with old visibility in search index

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -130,7 +130,11 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         getGraph().alterPropertyMetadatas((AccumuloElement) mutation.getElement(), mutation.getSetPropertyMetadatas());
 
         // altering properties comes next because alterElementVisibility may alter the vertex and we won't find it
-        getGraph().alterElementPropertyVisibilities((AccumuloElement) mutation.getElement(), mutation.getAlterPropertyVisibilities());
+        getGraph().alterElementPropertyVisibilities(
+                (AccumuloElement) mutation.getElement(),
+                mutation.getAlterPropertyVisibilities(),
+                authorizations
+        );
 
         Iterable<PropertyDeleteMutation> propertyDeletes = mutation.getPropertyDeletes();
         Iterable<PropertySoftDeleteMutation> propertySoftDeletes = mutation.getPropertySoftDeletes();

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3737,6 +3737,16 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_B).has("prop1", "value1").vertices()));
         Assert.assertEquals(0, count(graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices()));
 
+        Map<Object, Long> propertyCountByValue = queryGraphQueryWithTermsAggregation("prop1", ElementType.VERTEX, AUTHORIZATIONS_A);
+        if (propertyCountByValue != null) {
+            assertEquals(null, propertyCountByValue.get("value1"));
+        }
+
+        propertyCountByValue = queryGraphQueryWithTermsAggregation("prop1", ElementType.VERTEX, AUTHORIZATIONS_B);
+        if (propertyCountByValue != null) {
+            assertEquals(1L, (long) propertyCountByValue.get("value1"));
+        }
+
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
         Property v1Prop1 = v1.getProperty("prop1");
         assertNotNull(v1Prop1);


### PR DESCRIPTION
* [x] @sfeng88 

Unfortunately the unit tests I added won't catch this specific case because it only occurs when mixing ES with Accumulo. I kept them in because they are valid test cases.