### PR TITLE
Added: Vertex.query limited by connected edge labels

### DIFF
--- a/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
@@ -3,6 +3,7 @@ package org.vertexium.query;
 import org.vertexium.*;
 
 import java.util.EnumSet;
+import java.util.List;
 
 public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
     public DefaultVertexQuery(Graph graph, Vertex sourceVertex, String queryString, Authorizations authorizations) {
@@ -11,7 +12,16 @@ public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
 
     @Override
     public QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints) {
-        Iterable<Vertex> vertices = getSourceVertex().getVertices(Direction.BOTH, fetchHints, getParameters().getAuthorizations());
+        List<String> edgeLabels = getParameters().getEdgeLabels();
+        String[] edgeLabelsArray = edgeLabels == null || edgeLabels.size() == 0
+                ? null
+                : edgeLabels.toArray(new String[edgeLabels.size()]);
+        Iterable<Vertex> vertices = getSourceVertex().getVertices(
+                Direction.BOTH,
+                edgeLabelsArray,
+                fetchHints,
+                getParameters().getAuthorizations()
+        );
         return new DefaultGraphQueryIterableWithAggregations<>(getParameters(), vertices, true, true, true, getAggregations());
     }
 

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -204,7 +204,8 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                 throw new VertexiumException("Unexpected type " + has.getClass().getName());
             }
         }
-        if (getParameters().getEdgeLabels().size() > 0) {
+        if ((elementType == null || elementType == ElasticSearchElementType.EDGE)
+                && getParameters().getEdgeLabels().size() > 0) {
             String[] edgeLabelsArray = getParameters().getEdgeLabels().toArray(new String[getParameters().getEdgeLabels().size()]);
             filters.add(FilterBuilders.inFilter(ElasticsearchSingleDocumentSearchIndex.EDGE_LABEL_FIELD_NAME, edgeLabelsArray));
         }

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchVertexQuery.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchVertexQuery.java
@@ -35,7 +35,16 @@ public class ElasticSearchSingleDocumentSearchVertexQuery extends ElasticSearchS
     protected List<FilterBuilder> getFilters(ElasticSearchElementType elementType) {
         List<FilterBuilder> results = super.getFilters(elementType);
         if (elementType.equals(ElasticSearchElementType.VERTEX)) {
-            String[] ids = toArray(sourceVertex.getVertexIds(Direction.BOTH, getParameters().getAuthorizations()), String.class);
+            List<String> edgeLabels = getParameters().getEdgeLabels();
+            String[] edgeLabelsArray = edgeLabels == null || edgeLabels.size() == 0
+                    ? null
+                    : edgeLabels.toArray(new String[edgeLabels.size()]);
+            Iterable<String> vertexIds = sourceVertex.getVertexIds(
+                    Direction.BOTH,
+                    edgeLabelsArray,
+                    getParameters().getAuthorizations()
+            );
+            String[] ids = toArray(vertexIds, String.class);
             results.add(FilterBuilders.idsFilter().ids(ids));
         } else if (elementType.equals(ElasticSearchElementType.EDGE)) {
             FilterBuilder inVertexIdFilter = FilterBuilders.termFilter(ElasticsearchSingleDocumentSearchIndex.IN_VERTEX_ID_FIELD_NAME, sourceVertex.getId());

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -2822,6 +2822,10 @@ public abstract class GraphTestBase {
         edges = v1.query(AUTHORIZATIONS_A).hasEdgeLabel("edgeA").edges();
         Assert.assertEquals(1, count(edges));
         org.vertexium.test.util.IterableUtils.assertContains(ev1v2, edges);
+
+        vertices = v1.query(AUTHORIZATIONS_A).hasEdgeLabel("edgeA").vertices();
+        Assert.assertEquals(1, count(vertices));
+        org.vertexium.test.util.IterableUtils.assertContains(v2, vertices);
     }
 
     @Test


### PR DESCRIPTION
@sfeng88 

This commit adds Vertex.query support to query vertices only
connected with a given edge label. Previously any hasEdgeLabel
calls were ignored while querying for vertices from a vertex.