### PR TITLE
Changed: ElasticSearch: asynchronously submit element updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.4.6
 
 * Added: Optional benchmarks unit test
+* Changed: ElasticSearch: asynchronously submit element updates
 
 # v2.4.5
 


### PR DESCRIPTION
To speed up inserts/updates asynchronously submit element updates.

Benchmark times went from 38s to 3.8s