### PR TITLE
Changed: AccumuloGraph to use MultiTableBatchWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added: Optional benchmarks unit test
 * Changed: ElasticSearch: asynchronously submit element updates
+* Changed: AccumuloGraph to use MultiTableBatchWriter
 
 # v2.4.5
 


### PR DESCRIPTION
@sfeng88 @dsingley @mwizeman

According to the Accumulo documentation MultiTableBatchWriter class
enables efficient batch writing to multiple tables. When creating a
batch writer for each table, each has its own memory and network resources.
Using this class these resources may be shared among multiple tables.

### Benchmark:

#### Before change
add vertices in 4.188s
add edges in 7.733s

#### After change
add vertices in 4.052s
add edges in 6.296s