### PR TITLE
Changed: Speed up property reads by using Maps to directly get the property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.5.1
+
+* Changed: Speed up property reads by using Maps to directly get the property
+* Fixed: updated to repopulate the Metadata entriesLock in the case that the class gets deserialized
+
 # v2.5.0
 
 * Added: Optional benchmarks unit test

--- a/core/src/main/java/org/vertexium/util/PropertyCollection.java
+++ b/core/src/main/java/org/vertexium/util/PropertyCollection.java
@@ -1,0 +1,123 @@
+package org.vertexium.util;
+
+import org.vertexium.Property;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+public class PropertyCollection {
+    private final ConcurrentSkipListSet<Property> propertiesList = new ConcurrentSkipListSet<>();
+    private final Map<String, ConcurrentSkipListMap<String, ConcurrentSkipListSet<Property>>> propertiesByNameAndKey = new HashMap<>();
+
+    public Iterable<Property> getProperties() {
+        return propertiesList;
+    }
+
+    public synchronized Iterable<Property> getProperties(String key, String name) {
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(name);
+        if (propertiesByKey == null) {
+            return new ArrayList<>();
+        }
+        ConcurrentSkipListSet<Property> properties = propertiesByKey.get(key);
+        if (properties == null) {
+            return new ArrayList<>();
+        }
+        return properties;
+    }
+
+    public synchronized Iterable<Property> getProperties(String name) {
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(name);
+        if (propertiesByKey == null) {
+            return new ArrayList<>();
+        }
+        List<Property> results = new ArrayList<>();
+        for (ConcurrentSkipListSet<Property> properties : propertiesByKey.values()) {
+            results.addAll(properties);
+        }
+        return results;
+    }
+
+    public synchronized Property getProperty(String name, int index) {
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(name);
+        if (propertiesByKey == null) {
+            return null;
+        }
+        for (ConcurrentSkipListSet<Property> properties : propertiesByKey.values()) {
+            for (Property property : properties) {
+                if (index == 0) {
+                    return property;
+                }
+                index--;
+            }
+        }
+        return null;
+    }
+
+    public synchronized Property getProperty(String key, String name, int index) {
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(name);
+        if (propertiesByKey == null) {
+            return null;
+        }
+        ConcurrentSkipListSet<Property> properties = propertiesByKey.get(key);
+        if (properties == null) {
+            return null;
+        }
+        for (Property property : properties) {
+            if (index == 0) {
+                return property;
+            }
+            index--;
+        }
+        return null;
+    }
+
+    public synchronized void addProperty(Property property) {
+        ConcurrentSkipListMap<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(property.getName());
+        if (propertiesByKey == null) {
+            propertiesByKey = new ConcurrentSkipListMap<>();
+            this.propertiesByNameAndKey.put(property.getName(), propertiesByKey);
+        }
+        ConcurrentSkipListSet<Property> properties = propertiesByKey.get(property.getKey());
+        if (properties == null) {
+            properties = new ConcurrentSkipListSet<>();
+            propertiesByKey.put(property.getKey(), properties);
+        }
+        properties.add(property);
+        this.propertiesList.add(property);
+    }
+
+    public synchronized void removeProperty(Property property) {
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(property.getName());
+        if (propertiesByKey == null) {
+            return;
+        }
+        ConcurrentSkipListSet<Property> properties = propertiesByKey.get(property.getKey());
+        if (properties == null) {
+            return;
+        }
+        properties.remove(property);
+        this.propertiesList.remove(property);
+    }
+
+    public synchronized Iterable<Property> removeProperties(String name) {
+        List<Property> removedProperties = new ArrayList<>();
+        Map<String, ConcurrentSkipListSet<Property>> propertiesByKey = propertiesByNameAndKey.get(name);
+        if (propertiesByKey != null) {
+            for (ConcurrentSkipListSet<Property> properties : propertiesByKey.values()) {
+                for (Property property : properties) {
+                    removedProperties.add(property);
+                }
+            }
+        }
+
+        for (Property property : removedProperties) {
+            removeProperty(property);
+        }
+
+        return removedProperties;
+    }
+}

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5248,6 +5248,45 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void benchmarkGetPropertyByName() {
+        final int propertyCount = 100;
+
+        assumeTrue(benchmarkEnabled());
+        VertexBuilder m = graph.prepareVertex("v1", VISIBILITY_A);
+        for (int i = 0; i < propertyCount; i++) {
+            m.addPropertyValue("key", "prop" + i, "value " + i, VISIBILITY_A);
+        }
+        m.save(AUTHORIZATIONS_ALL);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_ALL);
+
+        double startTime = System.currentTimeMillis();
+        StringBuilder optimizationBuster = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            for (int propIndex = 0; propIndex < propertyCount; propIndex++) {
+                Object value = v1.getPropertyValue("key", "prop" + propIndex);
+                optimizationBuster.append(value.toString().substring(0, 1));
+            }
+        }
+        double endTime = System.currentTimeMillis();
+        LOGGER.trace("optimizationBuster: %s", optimizationBuster.substring(0, 1));
+        LOGGER.info("get property by name and key in %.3fs", (endTime - startTime) / 1000);
+
+        startTime = System.currentTimeMillis();
+        optimizationBuster = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            for (int propIndex = 0; propIndex < propertyCount; propIndex++) {
+                Object value = v1.getPropertyValue("prop" + propIndex);
+                optimizationBuster.append(value.toString().substring(0, 1));
+            }
+        }
+        endTime = System.currentTimeMillis();
+        LOGGER.trace("optimizationBuster: %s", optimizationBuster.substring(0, 1));
+        LOGGER.info("get property by name in %.3fs", (endTime - startTime) / 1000);
+    }
+
+    @Test
     public void benchmarkSaveElementMutations() {
         assumeTrue(benchmarkEnabled());
         int vertexCount = 1000;


### PR DESCRIPTION
Previously reading a property required looping over properties multiple
times to get the property of interest. This commit addresses this by
indexing the properties in a Map and getting them directly.