### PR TITLE
Fix maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>7</version>
+        <relativePath></relativePath>
     </parent>
 
     <groupId>org.vertexium</groupId>
@@ -80,6 +81,7 @@
         <maven.plugin.surefire.version>2.19.1</maven.plugin.surefire.version>
         <maven.plugin.buildnumber.version>1.2</maven.plugin.buildnumber.version>
         <maven.plugin.jarjar.version>1.9</maven.plugin.jarjar.version>
+        <maven.plugin.deploy.version>2.8.2</maven.plugin.deploy.version>
 
         <!-- used by: elasticsearch -->
         <elasticsearch.version>1.7.5</elasticsearch.version>
@@ -339,6 +341,11 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>jarjar-maven-plugin</artifactId>
                     <version>${maven.plugin.jarjar.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven.plugin.deploy.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Add a version number for the maven deploy plugin to remove warnings about malformed pom files. I also added an empty erlative path to the root node to ensure that we don't accidentally pick up a pom from the parent folder.