### PR TITLE
Bulk delete properties

### DIFF
--- a/core/src/main/java/org/vertexium/PropertyDescriptor.java
+++ b/core/src/main/java/org/vertexium/PropertyDescriptor.java
@@ -1,0 +1,77 @@
+package org.vertexium;
+
+import org.vertexium.mutation.PropertyDeleteMutation;
+import org.vertexium.mutation.PropertySoftDeleteMutation;
+
+/**
+ * Encapsulates the parameters necessary to perform a Property search
+ */
+public class PropertyDescriptor {
+    private final String key;
+    private final String name;
+    private final Visibility visibility;
+
+    public PropertyDescriptor(String key, String name, Visibility visibility) {
+        this.key = key;
+        this.name = name;
+        this.visibility = visibility;
+    }
+
+    public static PropertyDescriptor from(String key, String name, Visibility visibility) {
+        return new PropertyDescriptor(key, name, visibility);
+    }
+
+    public static PropertyDescriptor fromProperty(Property p) {
+        return new PropertyDescriptor(p.getKey(), p.getName(), p.getVisibility());
+    }
+
+    public static PropertyDescriptor fromPropertyDeleteMutation(PropertyDeleteMutation p) {
+        return new PropertyDescriptor(p.getKey(), p.getName(), p.getVisibility());
+    }
+
+    public static PropertyDescriptor fromPropertySoftDeleteMutation(PropertySoftDeleteMutation p) {
+        return new PropertyDescriptor(p.getKey(), p.getName(), p.getVisibility());
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    @Override
+    public String toString() {
+        return "PropertyDescriptor{" +
+                "key='" + key + '\'' +
+                ", name='" + name + '\'' +
+                ", visibility=" + visibility +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PropertyDescriptor that = (PropertyDescriptor) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        return visibility != null ? visibility.equals(that.visibility) : that.visibility == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (visibility != null ? visibility.hashCode() : 0);
+        return result;
+    }
+}

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -1,7 +1,10 @@
 package org.vertexium.search;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.vertexium.*;
 import org.vertexium.query.*;
+
+import java.util.Collection;
 
 import static org.vertexium.util.Preconditions.checkNotNull;
 
@@ -28,12 +31,7 @@ public class DefaultSearchIndex implements SearchIndex {
     }
 
     @Override
-    public void deleteProperty(Graph graph, Element element, Property property, Authorizations authorizations) {
-        checkNotNull(element, "element cannot be null");
-    }
-
-    @Override
-    public void deleteProperty(Graph graph, Element element, String propertyKey, String propertyName, Visibility propertyVisibility, Authorizations authorizations) {
+    public void deleteProperty(Graph graph, Element element, PropertyDescriptor property, Authorizations authorizations) {
         checkNotNull(element, "element cannot be null");
     }
 

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -6,19 +6,29 @@ import org.vertexium.query.MultiVertexQuery;
 import org.vertexium.query.SimilarToGraphQuery;
 import org.vertexium.query.VertexQuery;
 
+import java.util.Collection;
+
 public interface SearchIndex {
     void addElement(Graph graph, Element element, Authorizations authorizations);
 
     void deleteElement(Graph graph, Element element, Authorizations authorizations);
 
-    void deleteProperty(Graph graph, Element element, Property property, Authorizations authorizations);
+    /**
+     * Default delete property simply calls deleteProperty in a loop. It is up to the SearchIndex implementation to decide
+     * if a collective method can be made more efficient
+     */
+    default void deleteProperties(
+            Graph graph,
+            Element element,
+            Collection<PropertyDescriptor> propertyList,
+            Authorizations authorizations) {
+        propertyList.forEach(p -> deleteProperty(graph, element, p, authorizations));
+    }
 
     void deleteProperty(
             Graph graph,
             Element element,
-            String propertyKey,
-            String propertyName,
-            Visibility propertyVisibility,
+            PropertyDescriptor property,
             Authorizations authorizations
     );
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -1,9 +1,11 @@
 package org.vertexium.inmemory;
 
+import com.google.common.collect.Lists;
 import org.vertexium.*;
 import org.vertexium.mutation.*;
 import org.vertexium.property.MutablePropertyImpl;
 import org.vertexium.search.IndexHint;
+import org.vertexium.PropertyDescriptor;
 import org.vertexium.util.ConvertingIterable;
 import org.vertexium.util.FilterIterable;
 
@@ -475,10 +477,15 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> implemen
             Authorizations authorizations
     ) {
         if (alterPropertyVisibilities != null && alterPropertyVisibilities.size() > 0) {
-            for (AlterPropertyVisibility apv : alterPropertyVisibilities) {
-                Visibility existingVisibility = apv.getExistingVisibility();
-                getGraph().getSearchIndex().deleteProperty(getGraph(), element, apv.getKey(), apv.getName(), existingVisibility, authorizations);
-            }
+            // Bulk delete
+            List <PropertyDescriptor> propertyList = Lists.newArrayList();
+            alterPropertyVisibilities.forEach( p -> { propertyList.add(PropertyDescriptor.from(p.getKey(), p.getName(), p.getExistingVisibility()));});
+            getGraph().getSearchIndex().deleteProperties(
+                    getGraph(),
+                    element,
+                    propertyList,
+                    authorizations);
+
             getGraph().getSearchIndex().flush(getGraph());
         }
         if (newVisibility != null) {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -12,6 +12,7 @@ import org.vertexium.mutation.SetPropertyMetadata;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.property.StreamingPropertyValueRef;
 import org.vertexium.search.IndexHint;
+import org.vertexium.PropertyDescriptor;
 import org.vertexium.search.SearchIndex;
 import org.vertexium.util.*;
 
@@ -613,7 +614,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
             throw new IllegalArgumentException("Unexpected element type: " + inMemoryTableElement.getClass().getName());
         }
         if (indexHint != IndexHint.DO_NOT_INDEX) {
-            getSearchIndex().deleteProperty(this, element, property, authorizations);
+            getSearchIndex().deleteProperty(this, element, PropertyDescriptor.fromProperty(property), authorizations);
         }
 
         if (hasEventListeners()) {
@@ -762,7 +763,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         Property property = inMemoryTableElement.getProperty(key, name, visibility, authorizations);
         inMemoryTableElement.deleteProperty(key, name, visibility, authorizations);
 
-        getSearchIndex().deleteProperty(this, element, property, authorizations);
+        getSearchIndex().deleteProperty(this, element, PropertyDescriptor.fromProperty(property), authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new DeletePropertyEvent(this, element, property));


### PR DESCRIPTION
Added methods to support deleting multiple properties on a single ES request to minimize collisions.

Fixes: https://github.com/v5analytics/visallo-lts/issues/1983



