### PR TITLE
Fix: existing element mutations updating timestamps

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -140,8 +140,6 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         Iterable<PropertySoftDeleteMutation> propertySoftDeletes = mutation.getPropertySoftDeletes();
         Iterable<Property> properties = mutation.getProperties();
 
-        overridePropertyTimestamps(properties);
-
         updatePropertiesInternal(properties, propertyDeletes, propertySoftDeletes);
         getGraph().saveProperties(
                 (AccumuloElement) mutation.getElement(),
@@ -169,13 +167,5 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
     @Override
     public Iterable<HistoricalPropertyValue> getHistoricalPropertyValues(String key, String name, Visibility visibility, Long startTime, Long endTime, Authorizations authorizations) {
         return getGraph().getHistoricalPropertyValues(this, key, name, visibility, startTime, endTime, authorizations);
-    }
-
-    private void overridePropertyTimestamps(Iterable<Property> properties) {
-        for (Property property : properties) {
-            if (property instanceof MutableProperty) {
-                ((MutableProperty) property).setTimestamp(IncreasingTime.currentTimeMillis());
-            }
-        }
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1732,7 +1732,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             }
             elementMutationBuilder.addPropertySoftDeleteToMutation(m, property);
             property.setVisibility(apv.getVisibility());
-            property.setTimestamp(IncreasingTime.currentTimeMillis());
+            property.setTimestamp(apv.getTimestamp());
             elementMutationBuilder.addPropertyToMutation(this, m, elementRowKey, property);
 
             // delete the property with the old/existing visibility from the search index

--- a/accumulo/src/main/java/org/vertexium/accumulo/ElementMutationBuilder.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/ElementMutationBuilder.java
@@ -171,7 +171,7 @@ public abstract class ElementMutationBuilder {
     private void addPropertySoftDeleteToKeyValuePairs(List<KeyValuePair> results, Text elementRowKey, PropertySoftDeleteMutation propertySoftDeleteMutation) {
         Text columnQualifier = KeyHelper.getColumnQualifierFromPropertyColumnQualifier(propertySoftDeleteMutation.getKey(), propertySoftDeleteMutation.getName(), getNameSubstitutionStrategy());
         ColumnVisibility columnVisibility = visibilityToAccumuloVisibility(propertySoftDeleteMutation.getVisibility());
-        results.add(new KeyValuePair(new Key(elementRowKey, AccumuloElement.CF_PROPERTY_SOFT_DELETE, columnQualifier, columnVisibility, currentTimeMillis()), AccumuloElement.SOFT_DELETE_VALUE));
+        results.add(new KeyValuePair(new Key(elementRowKey, AccumuloElement.CF_PROPERTY_SOFT_DELETE, columnQualifier, columnVisibility, propertySoftDeleteMutation.getTimestamp()), AccumuloElement.SOFT_DELETE_VALUE));
     }
 
     public void saveEdgeBuilder(AccumuloGraph graph, EdgeBuilderBase edgeBuilder, long timestamp) {
@@ -439,7 +439,7 @@ public abstract class ElementMutationBuilder {
     public void addPropertySoftDeleteToMutation(Mutation m, PropertySoftDeleteMutation propertySoftDelete) {
         Text columnQualifier = KeyHelper.getColumnQualifierFromPropertyColumnQualifier(propertySoftDelete.getKey(), propertySoftDelete.getName(), getNameSubstitutionStrategy());
         ColumnVisibility columnVisibility = visibilityToAccumuloVisibility(propertySoftDelete.getVisibility());
-        m.put(AccumuloElement.CF_PROPERTY_SOFT_DELETE, columnQualifier, columnVisibility, currentTimeMillis(), AccumuloElement.SOFT_DELETE_VALUE);
+        m.put(AccumuloElement.CF_PROPERTY_SOFT_DELETE, columnQualifier, columnVisibility, propertySoftDelete.getTimestamp(), AccumuloElement.SOFT_DELETE_VALUE);
     }
 
     private StreamingPropertyValueRef saveStreamingPropertyValueSmall(String rowKey, Property property, byte[] data, StreamingPropertyValue propertyValue) {

--- a/core/src/main/java/org/vertexium/EdgeBuilderBase.java
+++ b/core/src/main/java/org/vertexium/EdgeBuilderBase.java
@@ -1,17 +1,20 @@
 package org.vertexium;
 
 import org.vertexium.mutation.EdgeMutation;
+import org.vertexium.util.IncreasingTime;
 
 public abstract class EdgeBuilderBase extends ElementBuilder<Edge> implements EdgeMutation {
     private final String edgeId;
     private final String label;
     private final Visibility visibility;
     private String newEdgeLabel;
+    private long alterEdgeLabelTimestamp;
 
     protected EdgeBuilderBase(String edgeId, String label, Visibility visibility) {
         this.edgeId = edgeId;
         this.label = label;
         this.visibility = visibility;
+        this.alterEdgeLabelTimestamp = IncreasingTime.currentTimeMillis();
     }
 
     public String getEdgeId() {
@@ -20,6 +23,11 @@ public abstract class EdgeBuilderBase extends ElementBuilder<Edge> implements Ed
 
     public String getLabel() {
         return label;
+    }
+
+    @Override
+    public long getAlterEdgeLabelTimestamp() {
+        return alterEdgeLabelTimestamp;
     }
 
     public Visibility getVisibility() {

--- a/core/src/main/java/org/vertexium/mutation/AlterPropertyVisibility.java
+++ b/core/src/main/java/org/vertexium/mutation/AlterPropertyVisibility.java
@@ -1,10 +1,12 @@
 package org.vertexium.mutation;
 
 import org.vertexium.Visibility;
+import org.vertexium.util.IncreasingTime;
 
 public class AlterPropertyVisibility {
     private final String key;
     private final String name;
+    private final long timestamp;
     private Visibility existingVisibility;
     private final Visibility visibility;
 
@@ -13,6 +15,11 @@ public class AlterPropertyVisibility {
         this.name = name;
         this.existingVisibility = existingVisibility;
         this.visibility = visibility;
+        this.timestamp = IncreasingTime.currentTimeMillis();
+
+        // org.vertexium.inmemory.InMemoryGraph.alterElementPropertyVisibilities() requires an additional timestamp
+        // to store the soft delete then the alter, this call will increment the counter
+        IncreasingTime.advanceTime(1);
     }
 
     public String getKey() {
@@ -25,6 +32,10 @@ public class AlterPropertyVisibility {
 
     public Visibility getExistingVisibility() {
         return existingVisibility;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public void setExistingVisibility(Visibility existingVisibility) {

--- a/core/src/main/java/org/vertexium/mutation/EdgeMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/EdgeMutation.java
@@ -6,4 +6,6 @@ public interface EdgeMutation extends ElementMutation<Edge> {
     EdgeMutation alterEdgeLabel(String newEdgeLabel);
 
     String getNewEdgeLabel();
+
+    long getAlterEdgeLabelTimestamp();
 }

--- a/core/src/main/java/org/vertexium/mutation/ExistingEdgeMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingEdgeMutation.java
@@ -1,9 +1,11 @@
 package org.vertexium.mutation;
 
 import org.vertexium.Edge;
+import org.vertexium.util.IncreasingTime;
 
 public abstract class ExistingEdgeMutation extends ExistingElementMutationImpl<Edge> implements EdgeMutation {
     private String newEdgeLabel;
+    private long alterEdgeLabelTimestamp;
 
     public ExistingEdgeMutation(Edge edge) {
         super(edge);
@@ -12,7 +14,13 @@ public abstract class ExistingEdgeMutation extends ExistingElementMutationImpl<E
     @Override
     public EdgeMutation alterEdgeLabel(String newEdgeLabel) {
         this.newEdgeLabel = newEdgeLabel;
+        alterEdgeLabelTimestamp = IncreasingTime.currentTimeMillis();
         return this;
+    }
+
+    @Override
+    public long getAlterEdgeLabelTimestamp() {
+        return alterEdgeLabelTimestamp;
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/mutation/KeyNameVisibilityPropertySoftDeleteMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/KeyNameVisibilityPropertySoftDeleteMutation.java
@@ -1,16 +1,19 @@
 package org.vertexium.mutation;
 
 import org.vertexium.Visibility;
+import org.vertexium.util.IncreasingTime;
 
 public class KeyNameVisibilityPropertySoftDeleteMutation extends PropertySoftDeleteMutation {
     private final String key;
     private final String name;
     private final Visibility visibility;
+    private final long timestamp;
 
     public KeyNameVisibilityPropertySoftDeleteMutation(String key, String name, Visibility visibility) {
         this.key = key;
         this.name = name;
         this.visibility = visibility;
+        this.timestamp = IncreasingTime.currentTimeMillis();
     }
 
     public String getKey() {
@@ -19,6 +22,11 @@ public class KeyNameVisibilityPropertySoftDeleteMutation extends PropertySoftDel
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public Visibility getVisibility() {

--- a/core/src/main/java/org/vertexium/mutation/PropertyPropertySoftDeleteMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/PropertyPropertySoftDeleteMutation.java
@@ -21,6 +21,11 @@ public class PropertyPropertySoftDeleteMutation extends PropertySoftDeleteMutati
     }
 
     @Override
+    public long getTimestamp() {
+        return property.getTimestamp();
+    }
+
+    @Override
     public Visibility getVisibility() {
         return property.getVisibility();
     }

--- a/core/src/main/java/org/vertexium/mutation/PropertySoftDeleteMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/PropertySoftDeleteMutation.java
@@ -7,6 +7,8 @@ public abstract class PropertySoftDeleteMutation implements Comparable<PropertyS
 
     public abstract String getName();
 
+    public abstract long getTimestamp();
+
     public abstract Visibility getVisibility();
 
     @Override

--- a/core/src/main/java/org/vertexium/util/IncreasingTime.java
+++ b/core/src/main/java/org/vertexium/util/IncreasingTime.java
@@ -12,4 +12,8 @@ public class IncreasingTime {
         }
         return last;
     }
+
+    public static void advanceTime(int inc) {
+        last += inc;
+    }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
@@ -341,8 +341,7 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
         this.mutations.add(new AddPropertyMetadataMutation(timestamp, key, name, metadata, visibility));
     }
 
-    public void appendAlterEdgeLabelMutation(String newEdgeLabel) {
-        long timestamp = IncreasingTime.currentTimeMillis();
+    public void appendAlterEdgeLabelMutation(long timestamp, String newEdgeLabel) {
         this.mutations.add(new AlterEdgeLabelMutation(timestamp, newEdgeLabel));
     }
 

--- a/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
@@ -164,8 +164,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public void appendAlterEdgeLabelMutation(String newEdgeLabel) {
-            sqlTableEdge.appendAlterEdgeLabelMutation(newEdgeLabel);
+        public void appendAlterEdgeLabelMutation(long timestamp, String newEdgeLabel) {
+            sqlTableEdge.appendAlterEdgeLabelMutation(timestamp, newEdgeLabel);
         }
 
         @Override

--- a/sql/src/main/java/org/vertexium/sql/SqlTableElement.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableElement.java
@@ -104,8 +104,8 @@ public abstract class SqlTableElement<TElement extends InMemoryElement>
     }
 
     @Override
-    public void appendAlterEdgeLabelMutation(String newEdgeLabel) {
-        super.appendAlterEdgeLabelMutation(newEdgeLabel);
+    public void appendAlterEdgeLabelMutation(long timestamp, String newEdgeLabel) {
+        super.appendAlterEdgeLabelMutation(timestamp, newEdgeLabel);
         store();
     }
 

--- a/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
@@ -19,8 +19,10 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
     }
 
     @Override
-    public InMemoryVertex createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime,
-                                                Authorizations authorizations) {
+    public InMemoryVertex createElementInternal(
+            InMemoryGraph graph, boolean includeHidden, Long endTime,
+            Authorizations authorizations
+    ) {
         return new InMemoryVertex(graph, getId(), asInMemoryTableElement(), includeHidden, endTime, authorizations);
     }
 
@@ -159,8 +161,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public void appendAlterEdgeLabelMutation(String newEdgeLabel) {
-            sqlTableVertex.appendAlterEdgeLabelMutation(newEdgeLabel);
+        public void appendAlterEdgeLabelMutation(long timestamp, String newEdgeLabel) {
+            sqlTableVertex.appendAlterEdgeLabelMutation(timestamp, newEdgeLabel);
         }
 
         @Override


### PR DESCRIPTION
Before this commit existing mutations would update the timestamp to now
losing the timestamp set in the mutations. This commit also fixes alter
edge label timestamps.