### PR TITLE
Added: support storing history in a separate table

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphConfiguration.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphConfiguration.java
@@ -33,6 +33,7 @@ public class AccumuloGraphConfiguration extends GraphConfiguration {
     public static final String ZOOKEEPER_SERVERS = "zookeeperServers";
     public static final String ZOOKEEPER_METADATA_SYNC_PATH = "zookeeperMetadataSyncPath";
     public static final String ACCUMULO_MAX_VERSIONS = "maxVersions";
+    public static final String HISTORY_IN_SEPARATE_TABLE = "historyInSeparateTable";
     public static final String NAME_SUBSTITUTION_STRATEGY_PROP_PREFIX = "nameSubstitutionStrategy";
     public static final String MAX_STREAMING_PROPERTY_VALUE_TABLE_DATA_SIZE = "maxStreamingPropertyValueTableDataSize";
     public static final String HDFS_USER = HDFS_CONFIG_PREFIX + ".user";
@@ -61,6 +62,7 @@ public class AccumuloGraphConfiguration extends GraphConfiguration {
     public static final Long DEFAULT_BATCHWRITER_TIMEOUT = Long.MAX_VALUE;
     public static final Integer DEFAULT_BATCHWRITER_MAX_WRITE_THREADS = 3;
     public static final Integer DEFAULT_ACCUMULO_MAX_VERSIONS = null;
+    public static final boolean DEFAULT_HISTORY_IN_SEPARATE_TABLE = false;
     public static final int DEFAULT_NUMBER_OF_QUERY_THREADS = 10;
     public static final String DEFAULT_HDFS_CONTEXT_CLASSPATH = null;
 
@@ -221,5 +223,9 @@ public class AccumuloGraphConfiguration extends GraphConfiguration {
 
     public String getZookeeperMetadataSyncPath() {
         return getString(ZOOKEEPER_METADATA_SYNC_PATH, DEFAULT_ZOOKEEPER_METADATA_SYNC_PATH);
+    }
+
+    public boolean isHistoryInSeparateTable() {
+        return getBoolean(HISTORY_IN_SEPARATE_TABLE, DEFAULT_HISTORY_IN_SEPARATE_TABLE);
     }
 }

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
@@ -49,7 +49,9 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         AccumuloGraphTestUtils.ensureTableExists(connector, GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX);
         AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getDataTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
         AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getVerticesTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
+        AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getHistoryVerticesTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
         AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getEdgesTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
+        AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getHistoryEdgesTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
         AccumuloGraphTestUtils.dropGraph(connector, AccumuloGraph.getMetadataTableName(GraphConfiguration.DEFAULT_TABLE_NAME_PREFIX));
         connector.securityOperations().changeUserAuthorizations(
                 AccumuloGraphConfiguration.DEFAULT_ACCUMULO_USERNAME,
@@ -126,6 +128,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         configMap.put(AccumuloGraphConfiguration.AUTO_FLUSH, false);
         configMap.put(AccumuloGraphConfiguration.MAX_STREAMING_PROPERTY_VALUE_TABLE_DATA_SIZE, GraphTestBase.LARGE_PROPERTY_VALUE_SIZE - 1);
         configMap.put(AccumuloGraphConfiguration.DATA_DIR, "/tmp/");
+        configMap.put(AccumuloGraphConfiguration.HISTORY_IN_SEPARATE_TABLE, true);
         return configMap;
     }
 


### PR DESCRIPTION
By storing the history in a separate table we reduce the overhead of
skipping historic items for 99% of queries which only care about the
current values