### PR TITLE
Fix metadata mutations on edge properties

### DIFF
--- a/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
@@ -169,6 +169,11 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
+        public void appendAddPropertyMetadataMutation(String key, String name, Metadata metadata, Visibility visibility, Long timestamp) {
+            sqlTableEdge.appendAddPropertyMetadataMutation(key, name, metadata, visibility, timestamp);
+        }
+
+        @Override
         protected List<Mutation> getFilteredMutations(boolean includeHidden, Long endTime, Authorizations authorizations) {
             return sqlTableEdge.getFilteredMutations(includeHidden, endTime, authorizations);
         }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3447,6 +3447,38 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testMetadataMutationsOnVertex() {
+        Metadata metadataPropB = new Metadata();
+        metadataPropB.add("meta1", "meta1", VISIBILITY_A);
+        Vertex vertex = graph.prepareVertex("v1", VISIBILITY_A)
+                .setProperty("propBmeta", "propBmeta", metadataPropB, VISIBILITY_A)
+                .save(AUTHORIZATIONS_ALL);
+        graph.flush();
+
+        ExistingElementMutation<Vertex> m = vertex.prepareMutation();
+        m.setPropertyMetadata("propBmeta", "meta1", "meta2", VISIBILITY_A);
+        vertex = m.save(AUTHORIZATIONS_ALL);
+
+        assertEquals("meta2", vertex.getProperty("propBmeta").getMetadata().getEntry("meta1").getValue());
+    }
+
+    @Test
+    public void testMetadataMutationsOnEdge() {
+        Metadata metadataPropB = new Metadata();
+        metadataPropB.add("meta1", "meta1", VISIBILITY_A);
+        Edge edge = graph.prepareEdge("v1", "v2", "label", VISIBILITY_A)
+                .setProperty("propBmeta", "propBmeta", metadataPropB, VISIBILITY_A)
+                .save(AUTHORIZATIONS_ALL);
+        graph.flush();
+
+        ExistingElementMutation<Edge> m = edge.prepareMutation();
+        m.setPropertyMetadata("propBmeta", "meta1", "meta2", VISIBILITY_A);
+        edge = m.save(AUTHORIZATIONS_ALL);
+
+        assertEquals("meta2", edge.getProperty("propBmeta").getMetadata().getEntry("meta1").getValue());
+    }
+
+    @Test
     public void testEmptyPropertyMutation() {
         Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_ALL);
         v1.prepareMutation().save(AUTHORIZATIONS_ALL);


### PR DESCRIPTION
SqlTableEdge wasn't overriding the `appendAddPropertyMetadataMutation` method that updated the sqlTableEdge mutations set.

Added unit tests for both vertices and edges